### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,31 @@
 ## Gio Core
 * [Gio Website](https://gioui.org/)
 * [Community call recordings](https://www.youtube.com/channel/UCzuKUnKK5gAFJKNyA1imIHw)
+* [Gio Examples Repository](https://git.sr.ht/~eliasnaur/gio-example)
+* [Gio Unstable/Experimental Libraries](https://git.sr.ht/~whereswaldon/gio-x), includes:
+    * more material design components
+    * radial, grid, and table layouts
+    * scroll bars
+    * haptic feedback
+    * notifications
+    * event management utilities
+    * user device preference access
+    * a simple color picker
+* [Gio OpenCollective](https://opencollective.com/gioui)
 
 ### Community Libraries
 
 * [Gio Canvas](https://github.com/ajstarks/giocanvas)
 * [Compute](https://github.com/vron/compute), compute shaders on the CPU
 * [IconVG](https://github.com/reactivego/ivg)
-* [Materials](https://git.sr.ht/~whereswaldon/materials), Material widgets
 * [Polyline](https://github.com/wrnrlr/polyline), draw polylines
 * [Material design icons](golang.org/x/exp/shiny/materialdesign/icons), Material design icons
-* [Colorpicker](https://git.sr.ht/~whereswaldon/colorpicker), input for colors
 * [Hyperlink](https://github.com/inkeliz/giohyperlink), open hyperlinks
 * [Webview](https://github.com/inkeliz/gowebview), web viewer
 * [P5](https://github.com/go-p5/p5), Processing like API to draw shapes
 * [nucular](https://github.com/aarzilli/nucular), alternative immediate-mode GUI framework in Go; supports Gio, shiny, and metal as graphical backends. Originally a source-port of [nuklear](https://github.com/vurtun/nuklear).
 
-### Software build with Gio
+### Software built with Gio
 
 * [Scatter](https://scatter.im/), an implementation of the Signal protocol over email.
 * [godcr](https://github.com/planetdecred/godcr), a cross-platform desktop wallet for the Decred cryptocurrency.
@@ -38,11 +47,6 @@
 ### Articles
 
 * [Novel State Management in Gio](https://jackmordaunt.srht.site/post/novel-state-management-in-gio/), Simplify state management by respecting the frame lifecycle: load data at the start of the frame and save data at the end of the frame.
-
-### More gio Links
-
-* [Gio Extras Demos](https://whereswaldon.github.io/gio-extras-index/)
-* [Gio Extras](https://sr.ht/~whereswaldon/gio-extras/)
 
 ## General GPU
 * [Raph GPU Resource](https://raphlinus.github.io/gpu/2020/02/12/gpu-resources.html)


### PR DESCRIPTION
This removes my old gio-extras repos because they have all been folded into the official `gioui.org/x` namespace. I add an entry describing that, and I also added our OpenCollective page while I was in here.